### PR TITLE
Support disabling domain reload

### DIFF
--- a/Scripts/Runtime/Core/DebugPanel.cs
+++ b/Scripts/Runtime/Core/DebugPanel.cs
@@ -94,7 +94,16 @@ namespace BrunoMikoski.DebugTools
         }
 
         private float previousTimeScale;
-        
+
+        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
+        static void SupportDomainReload()
+        {
+            LIFE_TIME_NON_MONOBEHAVIOUR = new List<object>(50);
+            LIFE_TIME_DYNAMIC_ACTIONS = new List<DebuggableAction>(100);
+            hasCachedInstance = default;
+            cachedInstance = null;
+        }
+
         private void Awake()
         {
             SetVisible(false);

--- a/Scripts/Runtime/UI/DebuggableInputFieldGUI.cs
+++ b/Scripts/Runtime/UI/DebuggableInputFieldGUI.cs
@@ -10,7 +10,7 @@ namespace BrunoMikoski.DebugTools.GUI
 {
     internal sealed class DebuggableInputFieldGUI : DebuggableFieldGUIBase
     {
-        private static Dictionary<Type, bool> DisplayableTypeToEditable => new Dictionary<Type, bool>
+        private static readonly Dictionary<Type, bool> DisplayableTypeToEditable = new Dictionary<Type, bool>
         {
             {typeof(float), true},
             {typeof(string), true},

--- a/Scripts/Runtime/UI/DebuggableToggleFieldGUI.cs
+++ b/Scripts/Runtime/UI/DebuggableToggleFieldGUI.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Reflection;
+﻿using System.Reflection;
 using UnityEngine;
 using UnityEngine.UI;
 
@@ -15,8 +14,6 @@ namespace BrunoMikoski.DebugTools.GUI
         private CanvasGroup contentsCanvasGroup;
         [SerializeField]
         private Toggle toggle;
-
-        private static Type[] DisplayableFieldInfoTypes => new[] { typeof(bool) };
 
         internal override void Initialize(DebuggableItemBase targetDebuggableItem, DebugPage targetDebugPage)
         {

--- a/Scripts/Runtime/Utils/CableCurve.cs
+++ b/Scripts/Runtime/Utils/CableCurve.cs
@@ -21,7 +21,8 @@ namespace UnityEngine.UI.Extensions
         [SerializeField]
         bool m_regen;
 
-        static Vector2[] emptyCurve = new Vector2[] { new Vector2(0.0f, 0.0f), new Vector2(0.0f, 0.0f) };
+        static readonly Vector2[] emptyCurve = new Vector2[] { new Vector2(0.0f, 0.0f), new Vector2(0.0f, 0.0f) };
+
         [SerializeField]
         Vector2[] points;
 

--- a/Scripts/Runtime/Utils/UILineRenderer.cs
+++ b/Scripts/Runtime/Utils/UILineRenderer.cs
@@ -141,9 +141,28 @@ namespace UnityEngine.UI.Extensions
 				m_segments = value;
 				SetAllDirty();
 			}
+        }
+
+        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
+        static void SupportDomainReload()
+        {
+
+            UV_TOP_LEFT =
+				UV_BOTTOM_LEFT =
+				UV_TOP_CENTER_LEFT =
+				UV_TOP_CENTER_RIGHT =
+				UV_BOTTOM_CENTER_LEFT =
+				UV_BOTTOM_CENTER_RIGHT =
+				UV_TOP_RIGHT = 
+				UV_BOTTOM_RIGHT = default;
+			
+			startUvs =
+				middleUvs =
+				endUvs =
+				fullUvs = null;
 		}
 
-		private void PopulateMesh(VertexHelper vh, Vector2[] pointsToDraw)
+        private void PopulateMesh(VertexHelper vh, Vector2[] pointsToDraw)
 		{
 			//If Bezier is desired, pick the implementation
 			if (BezierMode != BezierType.None && BezierMode != BezierType.Catenary && pointsToDraw.Length > 3) {

--- a/Scripts/Runtime/Utils/UIPrimitiveBase.cs
+++ b/Scripts/Runtime/Utils/UIPrimitiveBase.cs
@@ -46,6 +46,11 @@ namespace UnityEngine.UI.Extensions
             useLegacyMeshGeneration = false;
         }
 
+        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
+        static void SupportDomainReload()
+        {
+            s_ETC1DefaultUI = null;
+        }
         
         public static bool SetClass<T>(ref T currentValue, T newValue) where T : class
         {


### PR DESCRIPTION
Implement this method to reset some static fields when Domain Reload is disabled (or else Debug Panel will be broken under this condition).

```cs
[RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
static void SupportDomainReload()
{
}
```

Some other static fields are marked `readonly` to signify that they won't need to be reset.